### PR TITLE
Release 1.2.0: Add server_type parameter for Secret Server and Platform authentication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Delinea.SS Release Notes
 
 .. contents:: Topics
 
+v1.2.0
+======
+
+Release Summary
+---------------
+
+Added a new server_type parameter to support Secret Server and platform authentication.
 
 v1.1.0
 ======
@@ -20,7 +27,6 @@ Release Summary
 ---------------
 
 New plugin for getting secrets from Delinea Secret Server in Ansible.
-
 
 New Plugins
 -----------

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ ansible-galaxy collection install delinea.ss:==1.0.0
 
 See [Ansible Using collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
 
+## External requirements
+
+This collection requires the `python-tss-sdk` library to interact with Delinea Secret Server. You must install this Python package in your environment:
+
+```shell
+pip install python-tss-sdk
+```
+
+Refer to the [python-tss-sdk documentation](https://pypi.org/project/python-tss-sdk/) for more details and advanced usage.
+
 ## Contributing
 
 Read the [Development Guide](DEVELOPER.md) to learn about our build, test, and release processes.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -20,3 +20,10 @@ releases:
     fragments:
       - 1.1.0.yml
     release_date: '2023-09-13'
+  1.2.0:
+    changes:
+      release_summary: Added a new server_type parameter to support Secret Server
+        and platform authentication.
+    fragments:
+      - 1.2.0.yml
+    release_date: '2025-09-08'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ namespace: delinea
 name: ss
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.0
+version: 1.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.15.0'

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -50,8 +50,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        for line in data_as_list:
-            yield line
+        yield from data_as_list
 
     def mock_open(mock=None, read_data=''):
         """
@@ -79,8 +78,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            for line in _data:
-                yield line
+            yield from _data
 
         global file_spec
         if file_spec is None:


### PR DESCRIPTION
This pull request releases version 1.2.0 of the Delinea Secret Server Ansible Collection.

Key changes:

- Added a new server_type parameter to the tss lookup plugin, enabling support for both Secret Server and Platform authentication.
- Updated documentation and changelogs to reflect the new feature.
- Ensured compatibility with secret server/platform token and user credentials for secret access.