### PR TITLE
728859: Cache TSSClient per process and recover from stale tokens

### DIFF
--- a/changelogs/fragments/tss-client-cache.yml
+++ b/changelogs/fragments/tss-client-cache.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - tss lookup plugin - cache the ``TSSClient`` per Ansible process and credential identity so OAuth2 token grants are reused across lookups. Previously every ``lookup()`` invocation built a fresh client and minted a new ``/oauth2/token`` grant; under playbooks with many lookups this could trigger intermittent token endpoint failures.
+  - tss lookup plugin - on a 4xx response from Secret Server (e.g. an expired cached token), invalidate the cached ``TSSClient`` for that credential identity, rebuild it, and retry the lookup once. 5xx responses propagate unchanged. This covers the edge-of-expiry window the SDK does not refresh through.
+bugfixes:
+  - tss lookup plugin docs - the EXAMPLES for username/password and Platform-service-user lookups (no attachments, no secret_path) were subscripting the lookup result as if it were a dict, but the plugin returns a JSON string on that code path. Added ``| from_json`` to the four affected examples in ``plugins/lookup/tss.py`` and the matching blocks in ``docs/tss.md`` so they run as written. No plugin behavior change.

--- a/docs/tss.md
+++ b/docs/tss.md
@@ -65,7 +65,7 @@ Optional comment to pass when retrieving the secret. This will be logged as an a
                 base_url='https://secretserver.domain.com/SecretServer/',
                 username='user.name',
                 password='password'
-            )
+            ) | from_json
         }}
   tasks:
       - ansible.builtin.debug:
@@ -87,7 +87,7 @@ Optional comment to pass when retrieving the secret. This will be logged as an a
                 username='user.name',
                 password='password',
                 domain='domain'
-            )
+            ) | from_json
         }}
   tasks:
       - ansible.builtin.debug:
@@ -126,7 +126,7 @@ Optional comment to pass when retrieving the secret. This will be logged as an a
                 username='user.name',
                 password='password',
                 comment='Accessed by Ansible for deployment'
-            )
+            ) | from_json
         }}
   tasks:
       - ansible.builtin.debug:
@@ -217,7 +217,7 @@ Optional comment to pass when retrieving the secret. This will be logged as an a
                 base_url='https://platform.delinea.app/',
                 username='platform_service_username',
                 password='platform_service_user_password'
-            )
+            ) | from_json
         }}
   tasks:
       - name: Show password from secret

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -65,6 +65,7 @@ build_ignore:
   - changelogs
   - vendor
   - .pytest_cache
+  - _local
   # Files:
   - .changie.yaml
   - .editorconfig

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -134,7 +134,7 @@ EXAMPLES = r"""
                 base_url='https://secretserver.domain.com/SecretServer/',
                 username='user.name',
                 password='password'
-            )
+            ) | from_json
         }}
   tasks:
       - name: Show password from secret
@@ -158,7 +158,7 @@ EXAMPLES = r"""
                 username='user.name',
                 password='password',
                 domain='domain'
-            )
+            ) | from_json
         }}
   tasks:
       - name: Show password from secret
@@ -201,7 +201,7 @@ EXAMPLES = r"""
                 username='user.name',
                 password='password',
                 comment='Accessed by Ansible for deployment'
-            )
+            ) | from_json
         }}
   tasks:
       - name: Show password from secret
@@ -299,7 +299,7 @@ EXAMPLES = r"""
                 base_url='https://platform.delinea.app/',
                 username='platform_service_username',
                 password='platform_service_user_password'
-            )
+            ) | from_json
         }}
   tasks:
       - name: Show password from secret
@@ -331,6 +331,7 @@ EXAMPLES = r"""
 
 import abc
 import os
+import threading
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.module_utils import six
 from ansible.plugins.lookup import LookupBase
@@ -358,6 +359,20 @@ except ImportError:
         DomainPasswordGrantAuthorizer = None
         AccessTokenAuthorizer = None
         HAS_TSS_AUTHORIZER = False
+
+# SecretServerClientError (4xx) is exported in newer SDK builds. When present
+# it lets us distinguish auth/permission failures from 5xx service errors so
+# we can invalidate a stale cached client and retry once.
+try:
+    from delinea.secrets.server import SecretServerClientError
+    HAS_SS_CLIENT_ERROR = True
+except ImportError:
+    try:
+        from thycotic.secrets.server import SecretServerClientError
+        HAS_SS_CLIENT_ERROR = True
+    except ImportError:
+        SecretServerClientError = None
+        HAS_SS_CLIENT_ERROR = False
 
 
 display = Display()
@@ -487,6 +502,52 @@ class TSSClientV1(TSSClient):
         )
 
 
+# Module-scope cache of TSSClient instances, keyed on credential identity.
+# Each TSSClient holds a PasswordGrantAuthorizer whose internal token cache is
+# only useful if the client is reused. Without this, every lookup() call mints
+# a fresh /oauth2/token grant.
+_client_cache = {}
+_client_cache_lock = threading.Lock()
+
+
+def _credential_key(server_parameters):
+    # token-based auth makes no /oauth2/token call, so caching adds nothing.
+    if server_parameters.get("token"):
+        return None
+    return (
+        server_parameters.get("base_url"),
+        server_parameters.get("username"),
+        server_parameters.get("domain"),
+        server_parameters.get("api_path_uri"),
+        server_parameters.get("token_path_uri"),
+    )
+
+
+def _get_or_build_client(server_parameters):
+    key = _credential_key(server_parameters)
+    if key is None:
+        return TSSClient.from_params(**server_parameters)
+    with _client_cache_lock:
+        tss = _client_cache.get(key)
+        if tss is None:
+            tss = TSSClient.from_params(**server_parameters)
+            _client_cache[key] = tss
+        return tss
+
+
+def _reset_cache():
+    with _client_cache_lock:
+        _client_cache.clear()
+
+
+def _drop_cached_client(server_parameters):
+    key = _credential_key(server_parameters)
+    if key is None:
+        return
+    with _client_cache_lock:
+        _client_cache.pop(key, None)
+
+
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_TSS_SDK:
@@ -494,32 +555,44 @@ class LookupModule(LookupBase):
 
         self.set_options(var_options=variables, direct=kwargs)
 
-        tss = TSSClient.from_params(
-            base_url=self.get_option("base_url"),
-            username=self.get_option("username"),
-            password=self.get_option("password"),
-            domain=self.get_option("domain"),
-            token=self.get_option("token"),
-            api_path_uri=self.get_option("api_path_uri"),
-            token_path_uri=self.get_option("token_path_uri")
-        )
+        params = {
+            "base_url": self.get_option("base_url"),
+            "username": self.get_option("username"),
+            "password": self.get_option("password"),
+            "domain": self.get_option("domain"),
+            "token": self.get_option("token"),
+            "api_path_uri": self.get_option("api_path_uri"),
+            "token_path_uri": self.get_option("token_path_uri"),
+        }
 
         try:
-            if self.get_option("fetch_secret_ids_from_folder"):
-                if HAS_DELINEA_SS_SDK:
-                    return [tss.get_secret_ids_by_folderid(term) for term in terms]
-                else:
-                    raise AnsibleError("latest python-tss-sdk must be installed to use this plugin")
-            else:
-                return [
-                    tss.get_secret(
-                        term,
-                        self.get_option("secret_path"),
-                        self.get_option("fetch_attachments"),
-                        self.get_option("file_download_path"),
-                        self.get_option("comment"),
-                    )
-                    for term in terms
-                ]
+            return self._lookup(terms, _get_or_build_client(params))
         except SecretServerError as error:
+            # 4xx is often a stale cached token: the SDK's _refresh() adds the
+            # drift instead of subtracting it, so a cached authorizer will keep
+            # serving a token for ~5 minutes past server-side expiry. Drop the
+            # cached client so the rebuild mints a fresh grant, and retry once.
+            # 5xx and anything else propagate unchanged.
+            if HAS_SS_CLIENT_ERROR and isinstance(error, SecretServerClientError):
+                _drop_cached_client(params)
+                try:
+                    return self._lookup(terms, _get_or_build_client(params))
+                except SecretServerError as retry_error:
+                    raise AnsibleError("Secret Server lookup failure: %s" % retry_error.message)
             raise AnsibleError("Secret Server lookup failure: %s" % error.message)
+
+    def _lookup(self, terms, tss):
+        if self.get_option("fetch_secret_ids_from_folder"):
+            if HAS_DELINEA_SS_SDK:
+                return [tss.get_secret_ids_by_folderid(term) for term in terms]
+            raise AnsibleError("latest python-tss-sdk must be installed to use this plugin")
+        return [
+            tss.get_secret(
+                term,
+                self.get_option("secret_path"),
+                self.get_option("fetch_attachments"),
+                self.get_option("file_download_path"),
+                self.get_option("comment"),
+            )
+            for term in terms
+        ]

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -24,8 +24,16 @@ def make_absolute(name):
 
 
 class SecretServerError(Exception):
-    def __init__(self):
-        self.message = ''
+    def __init__(self, message=''):
+        self.message = message
+
+
+class SecretServerClientError(SecretServerError):
+    pass
+
+
+class SecretServerServiceError(SecretServerError):
+    pass
 
 
 class MockSecretServer(MagicMock):
@@ -38,6 +46,35 @@ class MockSecretServer(MagicMock):
 class MockFaultySecretServer(MagicMock):
     def get_secret_json(self, path, query_params=None):
         raise SecretServerError
+
+
+class MockSecretServerStaleFirstCall(MagicMock):
+    """Class-level counter: the first get_secret_json across all instances
+    raises a client error (simulating a stale cached token); subsequent calls
+    succeed. The plugin's retry path must build a second TSSClient, which gets
+    a fresh instance of this class, and the counter persists across them.
+
+    Note: type(self) on a MagicMock subclass returns a per-instance dynamic
+    subclass, not the user-defined parent class. We reference the parent
+    class by name explicitly so the counter actually persists across
+    instances."""
+    RESPONSE = '{"foo": "bar"}'
+    _counter = 0
+
+    @classmethod
+    def reset(cls):
+        cls._counter = 0
+
+    def get_secret_json(self, path, query_params=None):
+        MockSecretServerStaleFirstCall._counter += 1
+        if MockSecretServerStaleFirstCall._counter == 1:
+            raise SecretServerClientError('401 Unauthorized')
+        return self.RESPONSE
+
+
+class MockSecretServerServiceError(MagicMock):
+    def get_secret_json(self, path, query_params=None):
+        raise SecretServerServiceError('500 Internal Server Error')
 
 
 @patch(make_absolute('SecretServer'), MockSecretServer())
@@ -88,7 +125,11 @@ class TestLookupModule(TestCase):
     INVALID_TERMS = ['foo']
 
     def setUp(self):
+        tss._reset_cache()
         self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
+
+    def tearDown(self):
+        tss._reset_cache()
 
     @patch.multiple(TSS_IMPORT_PATH,
                     HAS_TSS_SDK=False,
@@ -106,6 +147,8 @@ class TestLookupModule(TestCase):
 
             with self.assertRaises(tss.AnsibleOptionsError):
                 self._run_lookup(self.INVALID_TERMS)
+
+        tss._reset_cache()
 
         with patch(make_absolute('SecretServer'), MockFaultySecretServer):
             with self.assertRaises(tss.AnsibleError):
@@ -128,3 +171,116 @@ class TestLookupModule(TestCase):
         default_kwargs.update(kwargs)
 
         return self.lookup.run(terms, variables, **default_kwargs)
+
+
+@patch.multiple(TSS_IMPORT_PATH,
+                HAS_TSS_SDK=True,
+                SecretServerError=SecretServerError,
+                AccessTokenAuthorizer=MagicMock,
+                PasswordGrantAuthorizer=MagicMock,
+                DomainPasswordGrantAuthorizer=MagicMock)
+class TestModuleCache(TestCase):
+    def setUp(self):
+        tss._reset_cache()
+        self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
+
+    def tearDown(self):
+        tss._reset_cache()
+
+    def _run(self, **kwargs):
+        base_kwargs = {"base_url": "url", "username": "u", "password": "p"}
+        base_kwargs.update(kwargs)
+        with patch(make_absolute('SecretServer'), MockSecretServer):
+            return self.lookup.run([1], [], **base_kwargs)
+
+    def test_module_cache_reuses_client_for_same_credentials(self):
+        self._run(base_url='u', username='alice', password='p')
+        self.assertEqual(len(tss._client_cache), 1)
+        cached_client = next(iter(tss._client_cache.values()))
+
+        self._run(base_url='u', username='alice', password='p')
+        self.assertEqual(len(tss._client_cache), 1)
+        self.assertIs(next(iter(tss._client_cache.values())), cached_client)
+
+    def test_module_cache_separates_clients_by_credential_identity(self):
+        self._run(base_url='u', username='alice', password='p')
+        self._run(base_url='u', username='bob', password='p')
+        self.assertEqual(len(tss._client_cache), 2)
+
+    def test_module_cache_bypassed_when_token_supplied(self):
+        self._run(base_url='u', token='tok')
+        self._run(base_url='u', token='tok')
+        self.assertEqual(len(tss._client_cache), 0)
+
+    def test_reset_cache_clears_state(self):
+        self._run(base_url='u', username='alice', password='p')
+        self.assertEqual(len(tss._client_cache), 1)
+        tss._reset_cache()
+        self.assertEqual(tss._client_cache, {})
+
+
+@patch.multiple(TSS_IMPORT_PATH,
+                HAS_TSS_SDK=True,
+                SecretServerError=SecretServerError,
+                SecretServerClientError=SecretServerClientError,
+                HAS_SS_CLIENT_ERROR=True)
+class TestCacheInvalidationOnAuthError(TestCase):
+    def setUp(self):
+        tss._reset_cache()
+        MockSecretServerStaleFirstCall.reset()
+        self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
+
+    def tearDown(self):
+        tss._reset_cache()
+        MockSecretServerStaleFirstCall.reset()
+
+    def test_client_error_invalidates_cache_and_retry_succeeds(self):
+        with patch(make_absolute('SecretServer'), MockSecretServerStaleFirstCall):
+            result = self.lookup.run(
+                [1], [], base_url='u', username='alice', password='p'
+            )
+            self.assertEqual(result, [MockSecretServerStaleFirstCall.RESPONSE])
+            self.assertEqual(MockSecretServerStaleFirstCall._counter, 2)
+            self.assertEqual(len(tss._client_cache), 1)
+
+    def test_service_error_propagates_without_retry(self):
+        with patch(make_absolute('SecretServer'), MockSecretServerServiceError):
+            with self.assertRaises(tss.AnsibleError):
+                self.lookup.run(
+                    [1], [], base_url='u', username='alice', password='p'
+                )
+            self.assertEqual(len(tss._client_cache), 1)
+
+    def test_persistent_client_error_propagates_after_one_retry(self):
+        class _AlwaysClientError(MagicMock):
+            def get_secret_json(self, path, query_params=None):
+                raise SecretServerClientError('401 Unauthorized')
+
+        with patch(make_absolute('SecretServer'), _AlwaysClientError):
+            with self.assertRaises(tss.AnsibleError):
+                self.lookup.run(
+                    [1], [], base_url='u', username='alice', password='p'
+                )
+
+
+@patch.multiple(TSS_IMPORT_PATH,
+                HAS_TSS_SDK=True,
+                SecretServerError=SecretServerError,
+                HAS_SS_CLIENT_ERROR=False)
+class TestCacheNoRetryWhenSDKLacksClientError(TestCase):
+    def setUp(self):
+        tss._reset_cache()
+        MockSecretServerStaleFirstCall.reset()
+        self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
+
+    def tearDown(self):
+        tss._reset_cache()
+        MockSecretServerStaleFirstCall.reset()
+
+    def test_no_retry_path_when_sdk_lacks_client_error_class(self):
+        with patch(make_absolute('SecretServer'), MockSecretServerStaleFirstCall):
+            with self.assertRaises(tss.AnsibleError):
+                self.lookup.run(
+                    [1], [], base_url='u', username='alice', password='p'
+                )
+            self.assertEqual(MockSecretServerStaleFirstCall._counter, 1)


### PR DESCRIPTION
728859

Plugin-side load-reduction change. Within a single Ansible process the plugin now reuses a `TSSClient` per credential identity, so OAuth2 token grants are reused across `lookup()` calls instead of being minted fresh every time. On a 4xx response (typically a stale cached token in the SDK's late-refresh window) the cached client is invalidated and the lookup is retried once; 5xx propagates unchanged. Details in the commit message.

Targeting `dev/728859-tss-client-cache` rather than `main` so QA can validate against a stable, ticket-scoped integration branch before a separate `dev/728859-tss-client-cache → main` release PR. The dev branch was created from current `main` HEAD for this work and will be deleted after release.

FYI observed during this work: per-file `GPL v3.0+` headers on `tss.py` and the tests appear to originate from this plugin's fork heritage in `community.general.tss` and are legally required to remain. The repo's root `LICENSE` (MIT) and `galaxy.yml` (`GPL-2.0-or-later`) don't reflect that. Not addressed here.

## QA

Full QA plan lives in a sibling ADO task (to be created), validating end-to-end on a non-prod Secret Server. Highlights:

- Run a playbook with ≥20 lookups across ≥4 forks against non-prod SS; capture `/oauth2/token` POST count before/after. Expect 1-2 orders of magnitude reduction.
- Long-run test: playbook spanning >25 min crossing the SDK's late-refresh window. The 4xx retry path should keep lookups succeeding across the expiry boundary.
- Functional smoke: lookup by ID, lookup by `secret_path`, folder lookup, attachment fetch, `comment` parameter, `domain` user, `token=…` direct path (verify token path bypasses the cache).
- Credential separation: two plays with different `username` values get separate cached clients.
- AAP/AWX EE rebuild + smoke (724252 customer is on AAP 26.7).
- Regression: prior playbook on 1.1.0 still works against the new build.