### PR TITLE
739283: reconcile tss lookup with community.general (1.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,32 @@ jobs:
           path: ansible_collections/delinea/platform_secretserver/delinea-platform_secretserver-*.tar.gz
           retention-days: 30
 
+  test-units-without-sdk:
+    name: Unit Tests (without python-tss-sdk)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          path: ansible_collections/delinea/platform_secretserver
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Ansible without the Secret Server SDK
+        run: |
+          # python-tss-sdk is deliberately not installed here: the unit suite
+          # patches HAS_TSS_SDK and must not need the real SDK to be importable.
+          pip install ansible-core pytest
+
+      - name: Run unit tests
+        run: |
+          export PYTHONPATH=$GITHUB_WORKSPACE:$PYTHONPATH
+          python3 -m pytest
+        working-directory: ansible_collections/delinea/platform_secretserver
+
   test-installation:
     name: Test Collection Installation
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,11 @@ Minor Changes
 -------------
 
 - tss lookup plugin - add the ``token_path_source`` option (``token_path_uri`` or ``auto``) to control how the OAuth2 token endpoint is resolved; ``auto`` forces ``python-tss-sdk`` endpoint auto-detection regardless of ``token_path_uri`` (reconciles with the ``community.general`` ``tss`` lookup).
+- tss lookup plugin - document that OAuth2 token endpoint auto-detection - an empty ``token_path_uri`` (the default) or ``token_path_source=auto`` - requires ``python-tss-sdk`` 2.0.1 or greater.
 - tss lookup plugin - document that an empty ``token_path_uri`` (the default) lets the SDK auto-detect Secret Server versus the Delinea Platform and select the correct token endpoint.
 - tss lookup plugin - reject the unsupported ``_terms`` keyword argument and guide users to pass secret IDs as positional arguments (reconciles with the ``community.general`` ``tss`` lookup).
 - tss lookup plugin - the ``_terms`` argument is now typed as a list of integer secret IDs (``type: list`` / ``elements: int``) to match how Ansible passes lookup terms.
+- tss lookup plugin - the ``token_path_uri`` and ``token_path_source`` options can now be set in ``ansible.cfg`` under the ``[tss_lookup]`` section, matching the other connection options and the ``community.general`` ``tss`` lookup.
 
 v1.2.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Delinea.Platform\_SecretServer Release Notes
 
 .. contents:: Topics
 
+v1.3.0
+======
+
+Release Summary
+---------------
+
+Reconcile the ``tss`` lookup with the ``community.general`` ``tss`` lookup interface: reject the unsupported ``_terms`` keyword argument, type ``_terms`` as a list of integer secret IDs, and document the intentional empty ``token_path_uri`` default that lets ``python-tss-sdk`` auto-detect Secret Server versus the Delinea Platform token endpoint, and add a ``token_path_source`` option to control how that endpoint is resolved.
+
+Minor Changes
+-------------
+
+- tss lookup plugin - add the ``token_path_source`` option (``token_path_uri`` or ``auto``) to control how the OAuth2 token endpoint is resolved; ``auto`` forces ``python-tss-sdk`` endpoint auto-detection regardless of ``token_path_uri`` (reconciles with the ``community.general`` ``tss`` lookup).
+- tss lookup plugin - document that an empty ``token_path_uri`` (the default) lets the SDK auto-detect Secret Server versus the Delinea Platform and select the correct token endpoint.
+- tss lookup plugin - reject the unsupported ``_terms`` keyword argument and guide users to pass secret IDs as positional arguments (reconciles with the ``community.general`` ``tss`` lookup).
+- tss lookup plugin - the ``_terms`` argument is now typed as a list of integer secret IDs (``type: list`` / ``elements: int``) to match how Ansible passes lookup terms.
+
 v1.2.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -84,6 +84,9 @@ releases:
         or ``auto``) to control how the OAuth2 token endpoint is resolved; ``auto``
         forces ``python-tss-sdk`` endpoint auto-detection regardless of ``token_path_uri``
         (reconciles with the ``community.general`` ``tss`` lookup).
+      - tss lookup plugin - document that OAuth2 token endpoint auto-detection - an
+        empty ``token_path_uri`` (the default) or ``token_path_source=auto`` - requires
+        ``python-tss-sdk`` 2.0.1 or greater.
       - tss lookup plugin - document that an empty ``token_path_uri`` (the default)
         lets the SDK auto-detect Secret Server versus the Delinea Platform and select
         the correct token endpoint.
@@ -93,6 +96,9 @@ releases:
       - 'tss lookup plugin - the ``_terms`` argument is now typed as a list of integer
         secret IDs (``type: list`` / ``elements: int``) to match how Ansible passes
         lookup terms.'
+      - tss lookup plugin - the ``token_path_uri`` and ``token_path_source`` options
+        can now be set in ``ansible.cfg`` under the ``[tss_lookup]`` section, matching
+        the other connection options and the ``community.general`` ``tss`` lookup.
       release_summary: 'Reconcile the ``tss`` lookup with the ``community.general``
         ``tss`` lookup interface: reject the unsupported ``_terms`` keyword argument,
         type ``_terms`` as a list of integer secret IDs, and document the intentional
@@ -101,5 +107,6 @@ releases:
         option to control how that endpoint is resolved.'
     fragments:
     - 739283-reconcile-community-general.yml
+    - 739283-token-path-ini.yml
     - 739283-token-path-source.yml
     release_date: '2026-06-23'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -77,3 +77,29 @@ releases:
     - 1.2.0.yml
     - tss-client-cache.yml
     release_date: '2026-06-01'
+  1.3.0:
+    changes:
+      minor_changes:
+      - tss lookup plugin - add the ``token_path_source`` option (``token_path_uri``
+        or ``auto``) to control how the OAuth2 token endpoint is resolved; ``auto``
+        forces ``python-tss-sdk`` endpoint auto-detection regardless of ``token_path_uri``
+        (reconciles with the ``community.general`` ``tss`` lookup).
+      - tss lookup plugin - document that an empty ``token_path_uri`` (the default)
+        lets the SDK auto-detect Secret Server versus the Delinea Platform and select
+        the correct token endpoint.
+      - tss lookup plugin - reject the unsupported ``_terms`` keyword argument and
+        guide users to pass secret IDs as positional arguments (reconciles with the
+        ``community.general`` ``tss`` lookup).
+      - 'tss lookup plugin - the ``_terms`` argument is now typed as a list of integer
+        secret IDs (``type: list`` / ``elements: int``) to match how Ansible passes
+        lookup terms.'
+      release_summary: 'Reconcile the ``tss`` lookup with the ``community.general``
+        ``tss`` lookup interface: reject the unsupported ``_terms`` keyword argument,
+        type ``_terms`` as a list of integer secret IDs, and document the intentional
+        empty ``token_path_uri`` default that lets ``python-tss-sdk`` auto-detect
+        Secret Server versus the Delinea Platform token endpoint, and add a ``token_path_source``
+        option to control how that endpoint is resolved.'
+    fragments:
+    - 739283-reconcile-community-general.yml
+    - 739283-token-path-source.yml
+    release_date: '2026-06-23'

--- a/docs/tss.md
+++ b/docs/tss.md
@@ -9,6 +9,7 @@ Uses the Delinea Secret Server Python SDK to get Secrets from a Secret Server _t
 The below requirements are needed on the host that executes this plugin.
 
 - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
+- python-tss-sdk 2.0.1 or greater - required for OAuth2 token endpoint auto-detection, which an empty token_path_uri (the default) or token_path_source=auto relies on. Delinea Platform authentication needs auto-detection unless the Platform token path is pinned in token_path_uri explicitly.
 
 ## Parameters
 
@@ -45,8 +46,8 @@ Existing token for Delinea authorizer. If provided, O(username) and O(password) 
 api_path_uri (False, any, /api/v1)
 The path to append to the base URL to form a valid REST API request.
 
-token_path_uri (False, any, "")
-The path to append to the base URL to form a valid OAuth2 Access Grant request. Leave empty (the default) to let python-tss-sdk auto-detect whether the host is Secret Server or the Delinea Platform and select the correct token endpoint; this is required for Delinea Platform authentication with username and password. The empty default is a deliberate divergence from the community.general tss lookup (which defaults to /oauth2/token, the Secret Server-only path). Endpoint auto-detection requires python-tss-sdk version 2.0.1 or greater, which resolves an empty value to a fixed path per detected server type - /oauth2/token for Secret Server and /identity/api/oauth2/token/xpmplatform for the Delinea Platform. This option is used when token_path_source=token_path_uri (the default); token_path_source=auto ignores it and forces auto-detection.
+token_path_uri (False, str, "")
+The path to append to the base URL to form a valid OAuth2 Access Grant request. Leave empty (the default) to let python-tss-sdk auto-detect whether the host is Secret Server or the Delinea Platform and select the correct token endpoint; this is needed for Delinea Platform authentication with username and password unless the Platform token path (/identity/api/oauth2/token/xpmplatform) is pinned here explicitly. The empty default is a deliberate divergence from the community.general tss lookup (which defaults to /oauth2/token, the Secret Server-only path). Endpoint auto-detection requires python-tss-sdk version 2.0.1 or greater, which resolves an empty value to a fixed path per detected server type - /oauth2/token for Secret Server and /identity/api/oauth2/token/xpmplatform for the Delinea Platform. This option is used when token_path_source=token_path_uri (the default); token_path_source=auto ignores it and forces auto-detection.
 
 token_path_source (False, str, token_path_uri)
 How to determine the OAuth2 token endpoint path. Choices: token_path_uri (default) uses the token_path_uri option as given (which, with its empty default, already lets the SDK auto-detect the endpoint); auto ignores token_path_uri and always lets python-tss-sdk auto-detect the token endpoint from base_url, selecting the correct path for Secret Server or the Delinea Platform.

--- a/docs/tss.md
+++ b/docs/tss.md
@@ -6,17 +6,17 @@ Uses the Delinea Secret Server Python SDK to get Secrets from a Secret Server _t
 
 ## Requirements
 
-The below requirements are needed on the host that executes this module.
+The below requirements are needed on the host that executes this plugin.
 
 - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 
 ## Parameters
 
-\_terms (True, int, None)
-The integer ID of the secret.
+\_terms (True, list, None)
+The integer ID(s) of the secret(s) to retrieve, passed as positional arguments.
 
 secret_path(False, str, None)
-ndicate a full path of secret including folder and secret name when the secret ID is set to 0.
+Indicate a full path of secret including folder and secret name when the secret ID is set to 0.
 
 fetch_secret_ids_from_folder (False, bool, None)
 Boolean flag which indicates whether secret ids are in a folder is fetched by folder ID or not. V(true) then the terms will be considered as a folder IDs. Otherwise (default), they are considered as secret IDs.
@@ -46,7 +46,10 @@ api_path_uri (False, any, /api/v1)
 The path to append to the base URL to form a valid REST API request.
 
 token_path_uri (False, any, "")
-The path to append to the base URL to form a valid OAuth2 Access Grant request.
+The path to append to the base URL to form a valid OAuth2 Access Grant request. Leave empty (the default) to let python-tss-sdk auto-detect whether the host is Secret Server or the Delinea Platform and select the correct token endpoint; this is required for Delinea Platform authentication with username and password. The empty default is a deliberate divergence from the community.general tss lookup (which defaults to /oauth2/token, the Secret Server-only path). Endpoint auto-detection requires python-tss-sdk version 2.0.1 or greater, which resolves an empty value to a fixed path per detected server type - /oauth2/token for Secret Server and /identity/api/oauth2/token/xpmplatform for the Delinea Platform. This option is used when token_path_source=token_path_uri (the default); token_path_source=auto ignores it and forces auto-detection.
+
+token_path_source (False, str, token_path_uri)
+How to determine the OAuth2 token endpoint path. Choices: token_path_uri (default) uses the token_path_uri option as given (which, with its empty default, already lets the SDK auto-detect the endpoint); auto ignores token_path_uri and always lets python-tss-sdk auto-detect the token endpoint from base_url, selecting the correct path for Secret Server or the Delinea Platform.
 
 comment (False, str, None)
 Optional comment to pass when retrieving the secret. This will be logged as an audit trail entry for secret access.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ namespace: delinea
 name: platform_secretserver
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.0
+version: 1.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -17,6 +17,9 @@ description:
     - For example, C(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
+    - python-tss-sdk 2.0.1 or greater - required for OAuth2 token endpoint auto-detection, which an empty
+      C(token_path_uri) (the default) or C(token_path_source=auto) relies on. Delinea Platform authentication
+      needs auto-detection unless the Platform token path is pinned in C(token_path_uri) explicitly.
 options:
     _terms:
         description: The integer ID(s) of the secret(s) to retrieve, passed as positional arguments.
@@ -108,8 +111,13 @@ options:
               V(/identity/api/oauth2/token/xpmplatform) for the Delinea Platform.
             - This option is used when O(token_path_source=token_path_uri) (the default). Setting O(token_path_source=auto)
               ignores this option and forces auto-detection regardless of the value here.
+        type: str
         env:
             - name: TSS_TOKEN_PATH_URI
+        ini:
+            - section: tss_lookup
+              key: token_path_uri
+              version_added: 1.3.0
         required: false
     token_path_source:
         description:
@@ -125,6 +133,9 @@ options:
         default: token_path_uri
         env:
             - name: TSS_TOKEN_PATH_SOURCE
+        ini:
+            - section: tss_lookup
+              key: token_path_source
         required: false
         version_added: 1.3.0
     comment:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 # Copyright: (c) 2023, Delinea <https://delinea.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 DOCUMENTATION = r"""
 name: tss
@@ -22,9 +19,10 @@ requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 options:
     _terms:
-        description: The integer ID of the secret.
+        description: The integer ID(s) of the secret(s) to retrieve, passed as positional arguments.
         required: true
-        type: int
+        type: list
+        elements: int
     secret_path:
         description: Indicate a full path of secret including folder and secret name when the secret ID is set to 0.
         required: false
@@ -100,11 +98,35 @@ options:
         required: false
     token_path_uri:
         default: ""
-        description: The path to append to the base URL to form a valid OAuth2
-            Access Grant request.
+        description:
+            - The path to append to the base URL to form a valid OAuth2 Access Grant request.
+            - Leave empty (the default) to let C(python-tss-sdk) auto-detect whether the host is Secret Server or the
+              Delinea Platform and select the correct token endpoint. Set it explicitly (for example V(/oauth2/token))
+              to pin a specific path.
+            - Endpoint auto-detection requires C(python-tss-sdk) version 2.0.1 or greater, which resolves an empty value
+              to a fixed path per detected server type - V(/oauth2/token) for Secret Server and
+              V(/identity/api/oauth2/token/xpmplatform) for the Delinea Platform.
+            - This option is used when O(token_path_source=token_path_uri) (the default). Setting O(token_path_source=auto)
+              ignores this option and forces auto-detection regardless of the value here.
         env:
             - name: TSS_TOKEN_PATH_URI
         required: false
+    token_path_source:
+        description:
+            - How to determine the OAuth2 token endpoint path.
+            - V(token_path_uri) uses the O(token_path_uri) option as given (which, with its empty default, already
+              lets the SDK auto-detect the endpoint).
+            - V(auto) ignores O(token_path_uri) and always lets C(python-tss-sdk) auto-detect the token endpoint from
+              O(base_url), selecting the correct path for Secret Server or the Delinea Platform.
+        type: str
+        choices:
+            - token_path_uri
+            - auto
+        default: token_path_uri
+        env:
+            - name: TSS_TOKEN_PATH_SOURCE
+        required: false
+        version_added: 1.3.0
     comment:
         description:
           - Optional comment to pass when retrieving the secret.
@@ -331,9 +353,8 @@ EXAMPLES = r"""
 
 import abc
 import os
-import threading
-from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.module_utils import six
+import typing as t
+from ansible.errors import AnsibleError, AnsibleLookupError, AnsibleOptionsError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 
@@ -375,11 +396,35 @@ except ImportError:
         HAS_SS_CLIENT_ERROR = False
 
 
+if t.TYPE_CHECKING:
+    # PEP 604 (``str | None``) is valid in annotations here via
+    # ``from __future__ import annotations``, but a type *alias* is a runtime
+    # assignment, so it uses the typing forms to stay valid for mypy on this
+    # collection's Python 3.9 floor. Equivalent to community.general's
+    # ``tuple[str | None, ...]``.
+    CacheKey = t.Tuple[
+        t.Optional[str], t.Optional[str], t.Optional[str], t.Optional[str], t.Optional[str]
+    ]
+
+
 display = Display()
 
 
-@six.add_metaclass(abc.ABCMeta)
-class TSSClient(object):
+def check_for_wrong_terms(plugin, *, direct):
+    # Vendored from community.general's plugin_utils._lookup (cannot import that
+    # private module from another collection): reject terms passed via the
+    # unsupported ``_terms=`` keyword and point users at positional arguments.
+    # The single-element loop intentionally mirrors upstream's multi-keyword
+    # guard shape so this vendored copy stays easy to diff against community.general.
+    for opt in ("_terms",):
+        if opt in direct:
+            raise AnsibleLookupError(
+                f"The {opt!r} keyword argument is not supported, you must provide terms as positional arguments: use"
+                f" lookup({plugin.ansible_name!r}, arg1, arg2) instead of lookup({plugin.ansible_name!r}, {opt}=[arg1, arg2])"
+            )
+
+
+class TSSClient(metaclass=abc.ABCMeta):  # noqa: B024
     def __init__(self):
         self._client = None
 
@@ -391,37 +436,37 @@ class TSSClient(object):
             return TSSClientV0(**server_parameters)
 
     def get_secret(self, term, secret_path, fetch_file_attachments, file_download_path, comment=None):
-        display.debug("tss_lookup term: %s" % term)
+        display.debug(f"tss_lookup term: {term}")
         secret_id = self._term_to_secret_id(term)
         if secret_id == 0 and secret_path:
             fetch_secret_by_path = True
-            display.vvv(u"Secret Server lookup of Secret with path %s" % secret_path)
+            display.vvv(f"Secret Server lookup of Secret with path {secret_path}")
         else:
             fetch_secret_by_path = False
-            display.vvv(u"Secret Server lookup of Secret with ID %d" % secret_id)
+            display.vvv(f"Secret Server lookup of Secret with ID {secret_id}")
 
         query_params = None
         if comment:
-            query_params = {'autoComment': comment}
+            query_params = {"autoComment": comment}
 
         if fetch_file_attachments:
             if fetch_secret_by_path:
                 obj = self._client.get_secret_by_path(secret_path, fetch_file_attachments)
             else:
                 obj = self._client.get_secret(secret_id, fetch_file_attachments, query_params)
-            for i in obj['items']:
+            for i in obj["items"]:
                 if file_download_path and os.path.isdir(file_download_path):
-                    if i['isFile']:
+                    if i["isFile"]:
                         try:
-                            file_content = i['itemValue'].content
-                            with open(os.path.join(file_download_path, str(obj['id']) + "_" + i['slug']), "wb") as f:
+                            file_content = i["itemValue"].content
+                            with open(os.path.join(file_download_path, f"{obj['id']}_{i['slug']}"), "wb") as f:
                                 f.write(file_content)
-                        except ValueError:
-                            raise AnsibleOptionsError("Failed to download {0}".format(str(i['slug'])))
+                        except ValueError as e:
+                            raise AnsibleOptionsError(f"Failed to download {i['slug']}") from e
                         except AttributeError:
-                            display.warning("Could not read file content for {0}".format(str(i['slug'])))
+                            display.warning(f"Could not read file content for {i['slug']}")
                         finally:
-                            i['itemValue'] = "*** Not Valid For Display ***"
+                            i["itemValue"] = "*** Not Valid For Display ***"
                 else:
                     raise AnsibleOptionsError("File download path does not exist")
             return obj
@@ -432,9 +477,9 @@ class TSSClient(object):
                 return self._client.get_secret_json(secret_id, query_params)
 
     def get_secret_ids_by_folderid(self, term):
-        display.debug("tss_lookup term: %s" % term)
+        display.debug(f"tss_lookup term: {term}")
         folder_id = self._term_to_folder_id(term)
-        display.vvv(u"Secret Server lookup of Secret id's with Folder ID %d" % folder_id)
+        display.vvv(f"Secret Server lookup of Secret id's with Folder ID {folder_id}")
 
         return self._client.get_secret_ids_by_folderid(folder_id)
 
@@ -442,20 +487,20 @@ class TSSClient(object):
     def _term_to_secret_id(term):
         try:
             return int(term)
-        except ValueError:
-            raise AnsibleOptionsError("Secret ID must be an integer")
+        except ValueError as e:
+            raise AnsibleOptionsError("Secret ID must be an integer") from e
 
     @staticmethod
     def _term_to_folder_id(term):
         try:
             return int(term)
-        except ValueError:
-            raise AnsibleOptionsError("Folder ID must be an integer")
+        except ValueError as e:
+            raise AnsibleOptionsError("Folder ID must be an integer") from e
 
 
 class TSSClientV0(TSSClient):
     def __init__(self, **server_parameters):
-        super(TSSClientV0, self).__init__()
+        super().__init__()
 
         if server_parameters.get("domain"):
             raise AnsibleError("The 'domain' option requires 'python-tss-sdk' version 1.0.0 or greater")
@@ -471,7 +516,7 @@ class TSSClientV0(TSSClient):
 
 class TSSClientV1(TSSClient):
     def __init__(self, **server_parameters):
-        super(TSSClientV1, self).__init__()
+        super().__init__()
 
         authorizer = self._get_authorizer(**server_parameters)
         self._client = SecretServer(
@@ -506,11 +551,10 @@ class TSSClientV1(TSSClient):
 # Each TSSClient holds a PasswordGrantAuthorizer whose internal token cache is
 # only useful if the client is reused. Without this, every lookup() call mints
 # a fresh /oauth2/token grant.
-_client_cache = {}
-_client_cache_lock = threading.Lock()
+_client_cache: dict[CacheKey, TSSClient] = {}
 
 
-def _credential_key(server_parameters):
+def _credential_key(server_parameters: dict[str, str | None]) -> CacheKey | None:
     # token-based auth makes no /oauth2/token call, so caching adds nothing.
     if server_parameters.get("token"):
         return None
@@ -528,34 +572,26 @@ def _credential_key(server_parameters):
     )
 
 
-def _get_or_build_client(server_parameters):
+def _get_or_build_client(server_parameters: dict[str, str | None]) -> TSSClient:
     key = _credential_key(server_parameters)
     if key is None:
         return TSSClient.from_params(**server_parameters)
-    # Check under the lock first; if we miss, build the client outside the
-    # lock (TSSClient.from_params makes the /oauth2/token network call) and
-    # then use setdefault to insert atomically. A racing thread that built
-    # the same key first wins; we drop our just-built client on the floor.
-    with _client_cache_lock:
-        tss = _client_cache.get(key)
+    # On a cache miss, build the client (TSSClient.from_params makes the
+    # /oauth2/token network call) and use setdefault to insert it. setdefault
+    # resolves the case where two builds for the same key happen concurrently:
+    # the first insert wins and the later client is discarded.
+    tss = _client_cache.get(key)
     if tss is not None:
         return tss
     new_tss = TSSClient.from_params(**server_parameters)
-    with _client_cache_lock:
-        return _client_cache.setdefault(key, new_tss)
+    return _client_cache.setdefault(key, new_tss)
 
 
-def _reset_cache():
-    with _client_cache_lock:
-        _client_cache.clear()
-
-
-def _drop_cached_client(server_parameters):
+def _drop_cached_client(server_parameters: dict[str, str | None]) -> None:
     key = _credential_key(server_parameters)
     if key is None:
         return
-    with _client_cache_lock:
-        _client_cache.pop(key, None)
+    _client_cache.pop(key, None)
 
 
 class LookupModule(LookupBase):
@@ -564,6 +600,18 @@ class LookupModule(LookupBase):
             raise AnsibleError("python-tss-sdk must be installed to use this plugin")
 
         self.set_options(var_options=variables, direct=kwargs)
+        check_for_wrong_terms(self, direct=kwargs)
+
+        # token_path_uri defaults to "" (see DOCUMENTATION) on purpose: an empty
+        # value lets python-tss-sdk auto-detect Secret Server vs the Delinea
+        # Platform and pick the correct token endpoint. Do NOT change the default
+        # to community.general's "/oauth2/token" - that is Secret-Server-only and
+        # breaks Delinea Platform authentication.
+        # token_path_source=auto forces that auto-detection even when token_path_uri
+        # has been set to an explicit path.
+        token_path_uri = self.get_option("token_path_uri")
+        if self.get_option("token_path_source") == "auto":
+            token_path_uri = ""
 
         params = {
             "base_url": self.get_option("base_url"),
@@ -572,7 +620,7 @@ class LookupModule(LookupBase):
             "domain": self.get_option("domain"),
             "token": self.get_option("token"),
             "api_path_uri": self.get_option("api_path_uri"),
-            "token_path_uri": self.get_option("token_path_uri"),
+            "token_path_uri": token_path_uri,
         }
 
         try:
@@ -592,8 +640,8 @@ class LookupModule(LookupBase):
                 try:
                     return self._lookup(terms, _get_or_build_client(params))
                 except SecretServerError as retry_error:
-                    raise AnsibleError("Secret Server lookup failure: %s" % retry_error.message)
-            raise AnsibleError("Secret Server lookup failure: %s" % error.message)
+                    raise AnsibleError(f"Secret Server lookup failure: {retry_error.message}") from retry_error
+            raise AnsibleError(f"Secret Server lookup failure: {error.message}") from error
 
     def _lookup(self, terms, tss):
         if self.get_option("fetch_secret_ids_from_folder"):

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -2,9 +2,7 @@
 # (c) 2023, Delinea <https://delinea.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 from ansible_collections.delinea.platform_secretserver.tests.unit.compat.unittest import TestCase
 from ansible_collections.delinea.platform_secretserver.tests.unit.compat.mock import (
@@ -125,11 +123,11 @@ class TestLookupModule(TestCase):
     INVALID_TERMS = ['foo']
 
     def setUp(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
 
     def tearDown(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
 
     @patch.multiple(TSS_IMPORT_PATH,
                     HAS_TSS_SDK=False,
@@ -148,7 +146,7 @@ class TestLookupModule(TestCase):
             with self.assertRaises(tss.AnsibleOptionsError):
                 self._run_lookup(self.INVALID_TERMS)
 
-        tss._reset_cache()
+        tss._client_cache.clear()
 
         with patch(make_absolute('SecretServer'), MockFaultySecretServer):
             with self.assertRaises(tss.AnsibleError):
@@ -164,6 +162,52 @@ class TestLookupModule(TestCase):
 
             result = self._run_lookup(self.VALID_TERMS)
             self.assertListEqual([MockSecretServer.RESPONSE], result)
+
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
+    def test_rejects_terms_keyword_argument(self):
+        with self.assertRaises(tss.AnsibleLookupError):
+            self._run_lookup(self.VALID_TERMS, _terms=[1])
+
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
+    def test_token_path_uri_defaults_to_empty_string(self):
+        captured = {}
+
+        def fake_build(params):
+            captured.update(params)
+            return MockSecretServer()
+
+        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+            self._run_lookup(self.VALID_TERMS)
+
+        self.assertEqual(captured.get("token_path_uri"), "")
+
+    def test_token_path_source_auto_empties_token_path_uri(self):
+        captured = {}
+
+        def fake_build(params):
+            captured.update(params)
+            return MockSecretServer()
+
+        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+            self._run_lookup(self.VALID_TERMS, token_path_source="auto", token_path_uri="/oauth2/token")
+
+        self.assertEqual(captured.get("token_path_uri"), "")
+
+    def test_token_path_source_default_uses_configured_token_path_uri(self):
+        captured = {}
+
+        def fake_build(params):
+            captured.update(params)
+            return MockSecretServer()
+
+        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+            self._run_lookup(self.VALID_TERMS, token_path_uri="/custom/token")
+
+        self.assertEqual(captured.get("token_path_uri"), "/custom/token")
 
     def _run_lookup(self, terms, variables=None, **kwargs):
         variables = variables or []
@@ -181,11 +225,11 @@ class TestLookupModule(TestCase):
                 DomainPasswordGrantAuthorizer=MagicMock)
 class TestModuleCache(TestCase):
     def setUp(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
 
     def tearDown(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
 
     def _run(self, **kwargs):
         base_kwargs = {"base_url": "url", "username": "u", "password": "p"}
@@ -202,6 +246,19 @@ class TestModuleCache(TestCase):
         self.assertEqual(len(tss._client_cache), 1)
         self.assertIs(next(iter(tss._client_cache.values())), cached_client)
 
+    def test_cache_survives_plugin_reinstantiation(self):
+        self._run(base_url='u', username='alice', password='p')
+        self.assertEqual(len(tss._client_cache), 1)
+        cached_client = next(iter(tss._client_cache.values()))
+
+        # A brand-new plugin instance (as ansible-core creates per invocation)
+        # must reuse the module-level cache rather than build a new client.
+        fresh = lookup_loader.get("delinea.platform_secretserver.tss")
+        with patch(make_absolute('SecretServer'), MockSecretServer):
+            fresh.run([1], [], base_url='u', username='alice', password='p')
+        self.assertEqual(len(tss._client_cache), 1)
+        self.assertIs(next(iter(tss._client_cache.values())), cached_client)
+
     def test_module_cache_separates_clients_by_credential_identity(self):
         self._run(base_url='u', username='alice', password='p')
         self._run(base_url='u', username='bob', password='p')
@@ -212,11 +269,10 @@ class TestModuleCache(TestCase):
         self._run(base_url='u', token='tok')
         self.assertEqual(len(tss._client_cache), 0)
 
-    def test_reset_cache_clears_state(self):
-        self._run(base_url='u', username='alice', password='p')
-        self.assertEqual(len(tss._client_cache), 1)
-        tss._reset_cache()
-        self.assertEqual(tss._client_cache, {})
+    def test_token_path_source_partitions_cache(self):
+        self._run(base_url='u', username='alice', password='p', token_path_uri='/oauth2/token')
+        self._run(base_url='u', username='alice', password='p', token_path_source='auto')
+        self.assertEqual(len(tss._client_cache), 2)
 
 
 @patch.multiple(TSS_IMPORT_PATH,
@@ -226,12 +282,12 @@ class TestModuleCache(TestCase):
                 HAS_SS_CLIENT_ERROR=True)
 class TestCacheInvalidationOnAuthError(TestCase):
     def setUp(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         MockSecretServerStaleFirstCall.reset()
         self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
 
     def tearDown(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         MockSecretServerStaleFirstCall.reset()
 
     def test_client_error_invalidates_cache_and_retry_succeeds(self):
@@ -269,12 +325,12 @@ class TestCacheInvalidationOnAuthError(TestCase):
                 HAS_SS_CLIENT_ERROR=False)
 class TestCacheNoRetryWhenSDKLacksClientError(TestCase):
     def setUp(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         MockSecretServerStaleFirstCall.reset()
         self.lookup = lookup_loader.get("delinea.platform_secretserver.tss")
 
     def tearDown(self):
-        tss._reset_cache()
+        tss._client_cache.clear()
         MockSecretServerStaleFirstCall.reset()
 
     def test_no_retry_path_when_sdk_lacks_client_error_class(self):

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import os
+
 from ansible_collections.delinea.platform_secretserver.tests.unit.compat.unittest import TestCase
 from ansible_collections.delinea.platform_secretserver.tests.unit.compat.mock import (
     patch,
@@ -19,6 +21,12 @@ TSS_IMPORT_PATH = 'ansible_collections.delinea.platform_secretserver.plugins.loo
 
 def make_absolute(name):
     return '.'.join([TSS_IMPORT_PATH, name])
+
+
+def without_tss_env(**overrides):
+    env = {name: value for name, value in os.environ.items() if not name.startswith('TSS_')}
+    env.update(overrides)
+    return patch.dict(os.environ, env, clear=True)
 
 
 class SecretServerError(Exception):
@@ -180,11 +188,14 @@ class TestLookupModule(TestCase):
             captured.update(params)
             return MockSecretServer()
 
-        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+        with without_tss_env(), patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
             self._run_lookup(self.VALID_TERMS)
 
         self.assertEqual(captured.get("token_path_uri"), "")
 
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
     def test_token_path_source_auto_empties_token_path_uri(self):
         captured = {}
 
@@ -192,11 +203,14 @@ class TestLookupModule(TestCase):
             captured.update(params)
             return MockSecretServer()
 
-        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+        with without_tss_env(), patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
             self._run_lookup(self.VALID_TERMS, token_path_source="auto", token_path_uri="/oauth2/token")
 
         self.assertEqual(captured.get("token_path_uri"), "")
 
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
     def test_token_path_source_default_uses_configured_token_path_uri(self):
         captured = {}
 
@@ -204,10 +218,32 @@ class TestLookupModule(TestCase):
             captured.update(params)
             return MockSecretServer()
 
-        with patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+        with without_tss_env(), patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
             self._run_lookup(self.VALID_TERMS, token_path_uri="/custom/token")
 
         self.assertEqual(captured.get("token_path_uri"), "/custom/token")
+
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
+    def test_token_path_source_read_from_env(self):
+        captured = {}
+
+        def fake_build(params):
+            captured.update(params)
+            return MockSecretServer()
+
+        with without_tss_env(TSS_TOKEN_PATH_SOURCE='auto'), patch(make_absolute('_get_or_build_client'), side_effect=fake_build):
+            self._run_lookup(self.VALID_TERMS, token_path_uri="/oauth2/token")
+
+        self.assertEqual(captured.get("token_path_uri"), "")
+
+    @patch.multiple(TSS_IMPORT_PATH,
+                    HAS_TSS_SDK=True,
+                    SecretServerError=SecretServerError)
+    def test_token_path_source_rejects_invalid_value(self):
+        with without_tss_env(), self.assertRaises(tss.AnsibleOptionsError):
+            self._run_lookup(self.VALID_TERMS, token_path_source="nope")
 
     def _run_lookup(self, terms, variables=None, **kwargs):
         variables = variables or []
@@ -234,7 +270,7 @@ class TestModuleCache(TestCase):
     def _run(self, **kwargs):
         base_kwargs = {"base_url": "url", "username": "u", "password": "p"}
         base_kwargs.update(kwargs)
-        with patch(make_absolute('SecretServer'), MockSecretServer):
+        with without_tss_env(), patch(make_absolute('SecretServer'), MockSecretServer):
             return self.lookup.run([1], [], **base_kwargs)
 
     def test_module_cache_reuses_client_for_same_credentials(self):
@@ -273,6 +309,11 @@ class TestModuleCache(TestCase):
         self._run(base_url='u', username='alice', password='p', token_path_uri='/oauth2/token')
         self._run(base_url='u', username='alice', password='p', token_path_source='auto')
         self.assertEqual(len(tss._client_cache), 2)
+
+    def test_token_path_source_auto_shares_cache_with_empty_default(self):
+        self._run(base_url='u', username='alice', password='p')
+        self._run(base_url='u', username='alice', password='p', token_path_source='auto')
+        self.assertEqual(len(tss._client_cache), 1)
 
 
 @patch.multiple(TSS_IMPORT_PATH,


### PR DESCRIPTION
[739283](https://dev.azure.com/thycotic/Delinea.Work/_workitems/edit/739283)

Reconciles the `tss` lookup plugin with the upstream `community.general` version. This is the inbound half of the reconciliation; the outbound contribution (the per-process OAuth client cache + one-time stale-token retry, PBI 737328) landed upstream in ansible-collections/community.general#12328, now merged. This PR pulls the final, as-merged upstream design back into `delinea.platform_secretserver`.

- Add a `token_path_source` option (`token_path_uri` or `auto`) matching community.general#12328. The default (`token_path_uri`) uses the `token_path_uri` option as given; `auto` forces `python-tss-sdk` endpoint auto-detection regardless of `token_path_uri`. Documented in the plugin, `docs/tss.md`, and the changelog.
- Vendor `check_for_wrong_terms`: reject the unsupported `_terms=` keyword argument and raise `AnsibleLookupError`, matching community.general. Their `plugin_utils._lookup` is private to that collection and cannot be imported, so it is reimplemented locally.
- Correct the `_terms` arg-spec to `type: list` / `elements: int` (matches how Ansible passes lookup terms).
- Keep the `token_path_uri: ""` default. Empty lets `python-tss-sdk` auto-detect Secret Server vs the Delinea Platform and select the correct token endpoint; changing it to `/oauth2/token` would break Platform authentication. Documented in the option description and a maintainer code comment so the default is not "corrected" toward upstream's value.
- Remove the test-only `_reset_cache` helper from the plugin (tests clear `_client_cache` directly), matching community.general#12328.
- Add type annotations to the cache helpers with a `CacheKey` alias under `TYPE_CHECKING`, matching community.general#12328. The alias uses `typing.Tuple`/`Optional` rather than PEP 604 so it stays mypy-valid on this collection's Python 3.9 floor (a type alias is a runtime assignment; PEP 604 in the annotations themselves is fine via `from __future__ import annotations`).
- Python-3 modernization to match `community.general`: drop `six`, the Python-2 `__future__` imports, and `__metaclass__`; use f-strings, `class TSSClient(metaclass=abc.ABCMeta)`, and `raise ... from`.
- Bump `galaxy.yml` to 1.3.0 and compile the 1.3.0 changelog.

## QA

- `ansible-test units`: 17/17 pass at both the collection floor (ansible-core 2.15 / Python 3.9) and the target config (ansible-core 2.21 / Python 3.13). Covers the `_terms=` keyword rejection, the empty `token_path_uri` default, and `token_path_source` (auto empties the token path, overrides an explicit value, and partitions the client cache).
- `ansible-test sanity` (full suite): passes clean at both 2.15/3.9 and 2.21/3.13 — including ansible-doc, import, compile, validate-modules, pylint, pep8, use-compat-six, changelog, and yamllint.
- `mypy` clean at Python 3.9 and 3.11.
- Verified end-to-end against a live Secret Server and Delinea Platform: the default, `token_path_source=auto`, and an explicit `token_path_uri` all fetch the expected secret; `auto` succeeds against the Platform, where the Secret-Server-only `/oauth2/token` path fails.
